### PR TITLE
Update to validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,8 +40,20 @@ internals.implementation = function (server, options) {
             }
             else { // see: http://hapijs.com/tutorials/auth for validateFunc signature
               options.validateFunc(decoded, request, function (err, valid) { // bring your own checks
+                
+                if(err) {
+                  return reply(Boom.badImplementation('Error occurred during validation'));
+                } else {
+                  if(valid) {
+                    return reply.coninue({ credentials: "See Authorization Header!" });
+                  } else {
+                    return reply(Boom.unauthorized('Credentials were not validated', 'Token'));
+                  }
+                }
+                
+                // ---- ORIGINAL CODE VVVVV ------ 
                 // Authenticated
-                return reply.continue({ credentials: "See Authorization Header!" });
+                //return reply.continue({ credentials: "See Authorization Header!" });
                 // the object containing a credentials property is REQUIRED by Hapi...
               });
             }


### PR DESCRIPTION
Validation was not checking against the second true/false argument passed to the callback function. Calling "callback(null, false)" when your custom validation method failed to validate a user would still return the route requested, as long as the provided JWT was decoded.

This may not be the desired correction, but it is working for me as a band-aid fix until it is incorporated officially. 

I hope I'm not all wet here with submitting this, I've been really happy with this JWT package after trying a couple others out and running into problems, so thanks for the good work!