### PR TITLE
Cleaned up error messages, removed JSON stringify for jwt errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,10 @@ Having a more real-world example was *seconded* by [@manonthemat](https://github
  signature `function(decoded, request, callback)` where:
     - `decoded` - (***required***) is the ***decoded*** JWT received from the client in **request.headers.authorization**
     - `request` - (***required***) is the original ***request*** received from the client  
-    - `callback` - (***required***) a callback function with the signature `function(err, isValid)` where:
+    - `callback` - (***required***) a callback function with the signature `function(err, isValid, credentials)` where:
         - `err` - an internal error.
         - `valid` - `true` if the JWT was valid, otherwise `false`.
+        - `credentials` - (***optional***) alternative credentials to be set instead of `decoded`.
 
 ### verifyOptions let you define how to Verify the Tokens (*Optional*)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,35 +17,39 @@ exports.register.attributes = {     // hapi requires attributes for a plugin.
 
 internals.implementation = function (server, options) {
 
-  Hoek.assert(options, 'Missing JWT auth options'); // pre-auth checks
-  Hoek.assert(options.key, 'options does not contain secret key'); // no signing key
-  Hoek.assert(typeof options.validateFunc === 'function', 'options.validateFunc MUST be a Valid Function');
+  Hoek.assert(options, 'options are required for jwt auth scheme'); // pre-auth checks
+  Hoek.assert(options.key, 'options must contain secret key'); // no signing key
+  Hoek.assert(typeof options.validateFunc === 'function', 'options.validateFunc must be a valid function');
 
   var scheme = {
     authenticate: function (request, reply) {
       var auth = request.headers.authorization;
       if (!auth) {
-        return reply(Boom.unauthorized(null, 'Token not present'));
+        return reply(Boom.unauthorized('Missing auth token'));
       }
       else { // strip pointless "Bearer " label & any whitespace > http://git.io/xP4F
         var token = auth.replace(/Bearer/gi,'').replace(/ /g,'');
         // rudimentary check for JWT validity see: http://git.io/xPBn for JWT format
-        if(token.split('.').length !== 3) {
-          return reply(Boom.unauthorized('Invalid Token (JWT) format', 'Token'));
+        if (token.split('.').length !== 3) {
+          return reply(Boom.unauthorized('Invalid token format', 'Token'));
         }
         else { // attempt to verify the token *asynchronously*
           var verifyOptions = options.verifyOptions || {};
-          JWT.verify(token, options.key, verifyOptions, function(err, decoded) {
+          JWT.verify(token, options.key, verifyOptions, function (err, decoded) {
             if (err) {
-              err.msg = 'Invalid Token';
-              return reply(Boom.unauthorized(JSON.stringify(err), 'Token'));
+              if (err.name === 'TokenExpiredError') {
+                return reply(Boom.unauthorized('Token expired', 'Token'));
+              }
+              else {
+                return reply(Boom.unauthorized('Invalid token', 'Token'));
+              }
             }
             else { // see: http://hapijs.com/tutorials/auth for validateFunc signature
               options.validateFunc(decoded, request, function (err, valid, credentials) { // bring your own checks
                 if (err) { // err sent as Boom attributes https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes
-                  return reply(Boom.unauthorized('Invalid token', 'Bearer'), null, err)
+                  return reply(Boom.unauthorized('Invalid token', 'Token'), null, err)
                 }
-                else if(!valid) {
+                else if (!valid) {
                   return reply(Boom.unauthorized('Invalid credentials', 'Token'), null, { credentials: credentials });
                 }
                 else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-jwt2",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Hapi.js Authentication Plugin/Scheme using JSON Web Tokens (JWT)",
   "main": "lib/index.js",
   "repository": {
@@ -15,6 +15,10 @@
     "JWT"
   ],
   "author": "@nelsonic <contact.nelsonic@gmail.com> (https://github.com/nelsonic)",
+  "contributors": [{
+    "name": "Kevin Wu",
+    "email": "kevindwusf@gmail.com"
+  }],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/ideaq/hapi-auth-jwt/issues"

--- a/test/server.js
+++ b/test/server.js
@@ -34,8 +34,7 @@ server.register(require('../'), function (err) {
 
   server.auth.strategy('jwt', 'jwt', {
     key: secret,
-    validateFunc: validate,
-    verifyOptions: { ignoreExpiration: true }
+    validateFunc: validate
   });
 
   server.route([

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,27 @@ test("Try using an incorrect secret to sign the JWT", function(t) {
   });
 });
 
+test("Try using an expired token", function(t) {
+  // use the token as the 'authorization' header in requests
+  var token = JWT.sign({ id:123,"name":"Charlie" }, secret, { expiresInSeconds: 1 });
+  console.log(" - - - - - - token  - - - - -")
+  console.log(token);
+  var options = {
+    method: "POST",
+    url: "/privado",
+    headers: { authorization: "Bearer "+token  }
+  };
+  // server.inject lets us similate an http request
+  setTimeout(function () {
+    server.inject(options, function(response) {
+      t.equal(response.statusCode, 401, "Expired token should be invalid");
+      t.equal(response.result.message, 'Token expired', 'Message should be "Token expired"')
+    t.equal(true, true, "true is true")
+      t.end();
+    });
+  }, 1000);
+});
+
 test("Token is well formed but is allowed=false so should be denied", function(t) {
   // use the token as the 'authorization' header in requests
   // var token = jwt.sign({ "id": 1 ,"name":"Old Greg" }, 'incorrectSecret');


### PR DESCRIPTION
- I added an explanation of how to use credentials in the README if the user does not want to use the decoded token

- I also updated a few of the error messages to be more clear when using the plugin.

- I added a test for expired tokens (which means I had to remove the ignoreExpiration flag)